### PR TITLE
Fix __dirname usage in Vite module loader

### DIFF
--- a/vite-module-loader.js
+++ b/vite-module-loader.js
@@ -1,6 +1,11 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { pathToFileURL } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+// Node ES modules do not provide __dirname by default. Derive it from
+// the current file URL so path resolution works correctly when this
+// script runs under "type": "module".
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function collectModuleAssetsPaths(paths, modulesPath) {
   modulesPath = path.join(__dirname, modulesPath);


### PR DESCRIPTION
## Summary
- handle `__dirname` in `vite-module-loader.js` when using ES modules

## Testing
- `node - <<'NODE'
import collectModuleAssetsPaths from './vite-module-loader.js';
console.log(typeof collectModuleAssetsPaths);
NODE
`

------
https://chatgpt.com/codex/tasks/task_b_6848e23522fc83228e4aa7abef4f0e8c