### PR TITLE
Add Docker compose and Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+storage
+vendor
+.env
+Dockerfile
+Dockerfile.*
+docker-compose.yml
+.git
+.gitignore
+

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,15 @@
+{
+    skip_install_trust
+    frankenphp {
+        document_root public/
+    }
+}
+
+:80 {
+    root * /app/public
+    encode zstd br gzip
+    php_server
+    file_server
+}
+
+import Caddyfile.d/*.caddyfile

--- a/Caddyfile
+++ b/Caddyfile
@@ -12,4 +12,3 @@
     file_server
 }
 
-import Caddyfile.d/*.caddyfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Stage 1: compile frontend assets
+FROM node:20-alpine AS node
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY resources ./resources
+COPY vite.config.js postcss.config.cjs tailwind.config.cjs ./
+RUN npm run build
+
+# Stage 2: install PHP dependencies
+FROM composer:2 AS vendor
+WORKDIR /app
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --optimize-autoloader --no-interaction
+
+# Stage 3: production image using FrankenPHP
+FROM dunglas/frankenphp:1-php8.3
+WORKDIR /app
+
+# copy application source
+COPY . .
+# copy built assets and vendor from previous stages
+COPY --from=node /app/public/build ./public/build
+COPY --from=vendor /app/vendor ./vendor
+
+RUN chown -R www-data:www-data storage bootstrap/cache
+
+EXPOSE 80
+CMD ["frankenphp", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY . .
 # copy built assets and vendor from previous stages
 COPY --from=node /app/public/build ./public/build
 COPY --from=vendor /app/vendor ./vendor
+RUN php artisan optimize
 
 RUN chown -R www-data:www-data storage bootstrap/cache
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - '8000:80'


### PR DESCRIPTION
## Summary
- add a Dockerfile using FrankenPHP and node build stage
- provide a Caddyfile for PHP and Caddy integration
- include docker-compose for running the container

## Testing
- `npm run build`
- `composer install --no-interaction`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_b_684f8ed093ec832298f7c46ae9457150